### PR TITLE
This commit addresses your feedback to refine the UI.

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -14,9 +14,8 @@ export default function RootLayout() {
       <Stack.Screen
         name="folder/[id]"
         options={{
-          title: 'My Notes',
           headerStyle: {
-            backgroundColor: '#121212',
+            backgroundColor: '#000000',
           },
           headerTintColor: '#FFFFFF',
           headerTitleStyle: {

--- a/app/folder/[id].tsx
+++ b/app/folder/[id].tsx
@@ -1,5 +1,6 @@
+import React, { useEffect, useMemo } from 'react';
 import { View, Text, StyleSheet, FlatList } from 'react-native';
-import { useLocalSearchParams } from 'expo-router';
+import { useLocalSearchParams, useNavigation } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { MaterialIcons } from '@expo/vector-icons';
 import NoteListItem, { Note } from '../../components/NoteListItem';
@@ -24,8 +25,15 @@ const FOLDERS_DATA: { [key: string]: { name: string; noteCount: number } } = {
 
 export default function NoteScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
-  const folderDetails = FOLDERS_DATA[id || '1'] || { name: 'Unknown Folder', noteCount: 0 };
+  const navigation = useNavigation();
 
+  const folderDetails = useMemo(() => {
+    return FOLDERS_DATA[id || '1'] || { name: 'Unknown Folder', noteCount: 0 };
+  }, [id]);
+
+  useEffect(() => {
+    navigation.setOptions({ title: folderDetails.name });
+  }, [navigation, folderDetails]);
 
   return (
     <SafeAreaView style={styles.container} edges={['bottom', 'left', 'right']}>
@@ -51,7 +59,7 @@ export default function NoteScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#121212',
+    backgroundColor: '#000000',
   },
   folderInfoContainer: {
     flexDirection: 'row',

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -52,7 +52,7 @@ export default function FoldersScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#111827', // bg-gray-900
+    backgroundColor: '#000000',
   },
   header: {
     color: '#FFFFFF', // text-white


### PR DESCRIPTION
- The background color of all screens has been changed to black (#000000) for a consistent theme.
- The title of the notes list screen (`folder/[id]`) is now dynamically set to the name of the folder, instead of the static "My Notes".
- Resolves a linting warning in `app/folder/[id].tsx` by using the `useMemo` hook to memoize folder details, preventing unnecessary re-renders of the `useEffect` that sets the header title.