### PR TITLE
This commit fixes a crash caused by a missing `useMemo` import in `ap…

### DIFF
--- a/app/folder/[id].tsx
+++ b/app/folder/[id].tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { Text, StyleSheet, FlatList, Alert } from 'react-native';
 import { useLocalSearchParams, useNavigation } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';


### PR DESCRIPTION
…p/folder/[id].tsx`.

The component was using the `useMemo` hook to memoize derived data, but the hook itself was not imported from React. This resulted in a runtime error. The import has been added to resolve the issue.